### PR TITLE
No division by zero if there are 0 requests

### DIFF
--- a/memcache-info
+++ b/memcache-info
@@ -209,16 +209,20 @@ function main()
     totalRequests=$(_calc $totalHits+$totalMisses)
     scale=2
     printf "$format" "Requests" $totalRequests
-    printf "$format" "Hits" "$totalHits" "$(_drawSparkLine $totalHits $totalRequests) ($(_calc 100*$totalHits/$totalRequests)%)"
-    printf "$format" "Misses" "$totalMisses" "$(_drawSparkLine $totalMisses $totalRequests) ($(_calc 100*$totalMisses/$totalRequests)%)"
-
+    if (($totalRequests > 0)); then
+        printf "$format" "Hits" "$totalHits" "$(_drawSparkLine $totalHits $totalRequests) ($(_calc 100*$totalHits/$totalRequests)%)"
+        printf "$format" "Misses" "$totalMisses" "$(_drawSparkLine $totalMisses $totalRequests) ($(_calc 100*$totalMisses/$totalRequests)%)"
+    fi
+    
     _echoB "Delete info"
     totalHits=$(getStatsInfo "delete_hits")
     totalMisses=$(getStatsInfo "delete_misses")
     totalRequests=$(_calc $totalHits+$totalMisses)
     printf "$format" "Requests" $totalRequests
-    printf "$format" "Hits" "$totalHits" "$(_drawSparkLine $totalHits $totalRequests) ($(_calc 100*$totalHits/$totalRequests)%)"
-    printf "$format" "Misses" "$totalMisses" "$(_drawSparkLine $totalMisses $totalRequests) ($(_calc 100*$totalMisses/$totalRequests)%)"
+    if (($totalRequests > 0)); then
+        printf "$format" "Hits" "$totalHits" "$(_drawSparkLine $totalHits $totalRequests) ($(_calc 100*$totalHits/$totalRequests)%)"
+        printf "$format" "Misses" "$totalMisses" "$(_drawSparkLine $totalMisses $totalRequests) ($(_calc 100*$totalMisses/$totalRequests)%)"
+    fi
     
     _echoB "Memory info"
     maxMemory=$( getLimitMaxBytes )


### PR DESCRIPTION
First of all, thank you very much for this cool script and for the well-written README!

---

Since my `memcached` server (apparently) never received any delete requests, the "Delete info" section looked like this:

```
Delete info

Requests           0
Runtime error (func=(main), adr=7): Divide by zero
Runtime error (func=(main), adr=15): Divide by zero
Hits               0           (%)
Runtime error (func=(main), adr=7): Divide by zero
Runtime error (func=(main), adr=15): Divide by zero
Misses             0           (%)
```

I took the liberty of (attempting to) fix this by checking whether `$totalRequests` in the delete (and get) info section is `> 0` and only then display (and calculate) the percentages -- and thus preventing the division by zero errors.

My knowledge of Bash is fairly limited, so I hope I didn't make any mistakes. Let me know if you'd like me to make any changes!